### PR TITLE
Serenity multiplexer fix

### DIFF
--- a/serenity_example/ku115dc/firmware/hdl/ku115dc_decl.vhd
+++ b/serenity_example/ku115dc/firmware/hdl/ku115dc_decl.vhd
@@ -13,7 +13,7 @@ use work.emp_device_types.all;
 -------------------------------------------------------------------------------
 package emp_project_decl is
 
-  constant PAYLOAD_REV        : std_logic_vector(31 downto 0) := X"12345678";
+  constant PAYLOAD_REV        : std_logic_vector(31 downto 0) := X"5109109F";
   
   -- Number of LHC bunches 
   constant LHC_BUNCH_COUNT    : integer             := 3564;

--- a/serenity_example/ku115dc_pfp/firmware/hdl/ku115dc_decl.vhd
+++ b/serenity_example/ku115dc_pfp/firmware/hdl/ku115dc_decl.vhd
@@ -13,7 +13,7 @@ use work.emp_device_types.all;
 -------------------------------------------------------------------------------
 package emp_project_decl is
 
-  constant PAYLOAD_REV        : std_logic_vector(31 downto 0) := X"12345678";
+  constant PAYLOAD_REV        : std_logic_vector(31 downto 0) := X"5109109F";
   
   -- Number of LHC bunches 
   constant LHC_BUNCH_COUNT    : integer             := 3564;


### PR DESCRIPTION
Fix multiplexer counter bug leading to low repeatability. Change algo revision number.

Now the counter in the multiplexer resets when the incoming data transitions from invalid to valid.